### PR TITLE
Expose global app and add parameter loader

### DIFF
--- a/dist/default_params.json
+++ b/dist/default_params.json
@@ -1,0 +1,62 @@
+{
+  "minorParams": {
+    "dsep": 20,
+    "dtest": 15,
+    "dstep": 1,
+    "dlookahead": 40,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "majorParams": {
+    "dsep": 100,
+    "dtest": 30,
+    "dstep": 1,
+    "dlookahead": 200,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "mainParams": {
+    "dsep": 400,
+    "dtest": 200,
+    "dstep": 1,
+    "dlookahead": 500,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "coastlineParams": {
+    "coastNoise": {
+      "noiseEnabled": true,
+      "noiseSize": 30,
+      "noiseAngle": 20
+    },
+    "riverNoise": {
+      "noiseEnabled": true,
+      "noiseSize": 30,
+      "noiseAngle": 20
+    },
+    "riverBankSize": 10,
+    "riverSize": 30,
+    "dsep": 20,
+    "dtest": 15,
+    "dstep": 1,
+    "dlookahead": 40,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 10000,
+    "seedTries": 300,
+    "simplifyTolerance": 10,
+    "collideEarly": 0
+  }
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -11,6 +11,11 @@
             <canvas id="map-canvas"></canvas>  <!-- Must match util.ts and style.css -->
             <canvas id="img-canvas"></canvas>
         </div>
+        <div id="controls">
+            <button onclick="window.mapGeneratorApp.generate()">Generate</button>
+            <button onclick="window.mapGeneratorApp.loadDefaultParams('default_params.json')">Load Defaults</button>
+            <button onclick="window.mapGeneratorApp.downloadSTL()">Download STL</button>
+        </div>
         <script src="bundle.js"></script>
     </body>
 </html>

--- a/src/default_params.json
+++ b/src/default_params.json
@@ -1,0 +1,62 @@
+{
+  "minorParams": {
+    "dsep": 20,
+    "dtest": 15,
+    "dstep": 1,
+    "dlookahead": 40,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "majorParams": {
+    "dsep": 100,
+    "dtest": 30,
+    "dstep": 1,
+    "dlookahead": 200,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "mainParams": {
+    "dsep": 400,
+    "dtest": 200,
+    "dstep": 1,
+    "dlookahead": 500,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 1000,
+    "seedTries": 300,
+    "simplifyTolerance": 0.5,
+    "collideEarly": 0
+  },
+  "coastlineParams": {
+    "coastNoise": {
+      "noiseEnabled": true,
+      "noiseSize": 30,
+      "noiseAngle": 20
+    },
+    "riverNoise": {
+      "noiseEnabled": true,
+      "noiseSize": 30,
+      "noiseAngle": 20
+    },
+    "riverBankSize": 10,
+    "riverSize": 30,
+    "dsep": 20,
+    "dtest": 15,
+    "dstep": 1,
+    "dlookahead": 40,
+    "dcirclejoin": 5,
+    "joinangle": 0.1,
+    "pathIterations": 10000,
+    "seedTries": 300,
+    "simplifyTolerance": 10,
+    "collideEarly": 0
+  }
+}

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -11,6 +11,11 @@
             <canvas id="map-canvas"></canvas>  <!-- Must match util.ts and style.css -->
             <canvas id="img-canvas"></canvas>
         </div>
+        <div id="controls">
+            <button onclick="window.mapGeneratorApp.generate()">Generate</button>
+            <button onclick="window.mapGeneratorApp.loadDefaultParams('default_params.json')">Load Defaults</button>
+            <button onclick="window.mapGeneratorApp.downloadSTL()">Download STL</button>
+        </div>
         <script src="bundle.js"></script>
     </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,6 +279,30 @@ class Main {
         element.clear();
     }
 
+    async loadDefaultParams(jsonUrl: string): Promise<void> {
+        try {
+            const response = await fetch(jsonUrl);
+            const params = await response.json();
+            const gui: any = this.mainGui as any;
+
+            if (params.coastlineParams) {
+                Object.assign(gui.coastlineParams, params.coastlineParams);
+            }
+            if (params.mainParams) {
+                Object.assign(gui.mainParams, params.mainParams);
+            }
+            if (params.majorParams) {
+                Object.assign(gui.majorParams, params.majorParams);
+            }
+            if (params.minorParams) {
+                Object.assign(gui.minorParams, params.minorParams);
+            }
+            Util.updateGui(this.roadsFolder);
+        } catch (e) {
+            log.error('Failed to load parameters', e);
+        }
+    }
+
     private showTensorField(): boolean {
         return !this.tensorFolder.closed || this.mainGui.roadsEmpty();
     }
@@ -322,5 +346,6 @@ class Main {
 // Add log to window so we can use log.setlevel from the console
 (window as any).log = log;
 window.addEventListener('load', (): void => {
-    new Main();
+    const app = new Main();
+    (window as any).mapGeneratorApp = app;   // expose for custom HTML
 });


### PR DESCRIPTION
## Summary
- expose `Main` instance as `mapGeneratorApp`
- load default parameters from JSON into the GUI
- add UI buttons in `index.html`
- provide a sample `default_params.json`
- update built bundle

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685125b5ba6c832988e5c18c01f1587e